### PR TITLE
Fix nested routers `routes`

### DIFF
--- a/backbone.routemanager.js
+++ b/backbone.routemanager.js
@@ -73,7 +73,11 @@ var RouteManager = Backbone.Router.extend({
             _.each(this.routes, function(method, route) {
               delete this.routes[route];
 
-              route = route ? prefix + "/" + route : prefix;
+              route = route ? prefix + route : prefix;
+
+              if (route[route.length-1] === "/") {
+                route = route.slice(0, route.length-1);
+              }
 
               // Replace the route with the override
               this.routes[route] = method;


### PR DESCRIPTION
Before, routes names wheren't mapped correctly with their prefix, giving:

```
"" -> "main/",
":id" -> "main//:id"
"test" -> "main//test"
```

Now they're mapped correctly to usable routes by backbone routers.

```
"" -> "main",
":id" -> "main/:id"
"test" -> "main/test"
```
